### PR TITLE
Add nonce to editor AJAX requests

### DIFF
--- a/includes/class-cai-editor.php
+++ b/includes/class-cai-editor.php
@@ -10,11 +10,13 @@ class CAI_Editor {
         ?>
         <script>
         jQuery(function($){
+            const caiNonce = (typeof caiVars !== 'undefined' && caiVars.nonce) ? caiVars.nonce : '';
+            const ajaxUrl = (typeof caiVars !== 'undefined' && caiVars.ajaxurl) ? caiVars.ajaxurl : ajaxurl;
             $('#cai-generate-meta').on('click', function(e){
                 e.preventDefault();
                 const postId = $(this).data('post');
                 $(this).prop('disabled', true).text('יוצר...');
-                $.post(ajaxurl, { action:'cai_generate_meta', post_id: postId }, function(resp){
+                $.post(ajaxUrl, { action:'cai_generate_meta', post_id: postId, nonce: caiNonce }, function(resp){
                     if(resp && resp.success && resp.data){
                         if(resp.data.title) $('input[name="cai_meta_title"]').val(resp.data.title);
                         if(resp.data.description) $('textarea[name="cai_meta_desc"]').val(resp.data.description);
@@ -30,7 +32,7 @@ class CAI_Editor {
                 if(!topic){ alert('נא להזין נושא'); return; }
                 const $btn = $(this);
                 $btn.prop('disabled', true).text('יוצר תוכן...');
-                $.post(ajaxurl, { action:'cai_generate_from_topic', topic: topic }, function(resp){
+                $.post(ajaxUrl, { action:'cai_generate_from_topic', topic: topic, nonce: caiNonce }, function(resp){
                     if(resp && resp.success && resp.data && resp.data.post_id){
                         alert('נוצר פוסט #' + resp.data.post_id);
                         location.href = resp.data.edit_link || location.href;
@@ -44,7 +46,7 @@ class CAI_Editor {
                 e.preventDefault();
                 const $btn = $(this);
                 $btn.prop('disabled', true).text('מריץ...');
-                $.post(ajaxurl, { action:'cai_reindex' }, function(resp){
+                $.post(ajaxUrl, { action:'cai_reindex', nonce: caiNonce }, function(resp){
                     $('#cai-reindex-log').text(JSON.stringify(resp, null, 2));
                     $btn.prop('disabled', false).text('הפעל אינדוקס');
                 });


### PR DESCRIPTION
## Summary
- add nonce support to editor screen AJAX requests using localized caiVars data
- ensure editor inline script reads caiVars ajax URL and nonce before firing requests

## Testing
- not run (environment does not provide WordPress runtime)


------
https://chatgpt.com/codex/tasks/task_e_68cc5c22dd8883239b9d5e2709da6d6c