### PR TITLE
Fix CAI enhancements constructor closure

### DIFF
--- a/includes/class-cai-enhancements.php
+++ b/includes/class-cai-enhancements.php
@@ -13,7 +13,7 @@ class CAI_Enhancements {
         add_shortcode('cai_updated', [$this,'updated']);
         add_shortcode('cai_cluster', [$this,'cluster_name']);
         add_shortcode('cai_cluster_posts', [$this,'cluster_posts']);
-    
+    }
 
     public function author_box(){
         if (!is_singular()) return '';
@@ -76,8 +76,6 @@ class CAI_Enhancements {
         wp_reset_postdata();
         return $html;
     }
-
-}
 
     // Simple Table of Contents from the_content
     public function toc($atts = []){


### PR DESCRIPTION
## Summary
- close the CAI enhancements constructor immediately after shortcode registration
- keep all enhancement methods at the class scope without extra braces

## Testing
- php -l includes/class-cai-enhancements.php

------
https://chatgpt.com/codex/tasks/task_e_68cc5c1d67148323b2d9b05329f15572