### PR TITLE
Restore ajax_test_ai method inside CAI_REST

### DIFF
--- a/includes/class-cai-rest.php
+++ b/includes/class-cai-rest.php
@@ -58,9 +58,6 @@ if (!current_user_can('manage_options')) wp_send_json_error('forbidden', 403);
         $res = $this->reindex_all();
         wp_send_json_success($res);
     }
-}
-
-
     public function ajax_test_ai(){
         check_ajax_referer('cai-admin','nonce');
         if (!current_user_can('manage_options')) wp_send_json_error('forbidden', 403);
@@ -68,3 +65,4 @@ if (!current_user_can('manage_options')) wp_send_json_error('forbidden', 403);
         if (is_wp_error($res)) wp_send_json_error($res->get_error_message());
         wp_send_json_success(['ok'=>$res]);
     }
+}


### PR DESCRIPTION
## Summary
- move the ajax_test_ai handler back inside the CAI_REST class definition so it registers correctly
- ensure the class now closes after the ajax_test_ai method to avoid stray lines

## Testing
- php -l includes/class-cai-rest.php

------
https://chatgpt.com/codex/tasks/task_e_68cc5c1716c48323b4b6414f1387b892